### PR TITLE
Update xgl.yaml to show persistent folder in the gui

### DIFF
--- a/xgl.yaml
+++ b/xgl.yaml
@@ -75,7 +75,7 @@ spec:
       name: dshm
     - mountPath: /cache
       name: xgl-cache-vol
-    - mountPath: /mnt/persistent
+    - mountPath: /home/ubuntu/persistent
       name: xgl-root-vol
   dnsPolicy: None
   dnsConfig:


### PR DESCRIPTION
The persistent folder was hidden behind another folder, so I changed the yaml file to just put it in the home directory.